### PR TITLE
Remove pygame requirement if not installed, alter main loop to large size

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -245,7 +245,7 @@ def recordMousePositions(amount=None, interval=2, debug=False):
         mixer.init()
 
         file_path = os.path.dirname(os.path.realpath(__file__))
-        file_location = os.path.join(file_path, 'ding.wav')
+        file_location = os.path.join(file_path, 'resources', 'ding.wav')
 
         # Loading the "ding" sound effect.
         ding = mixer.Sound(file_location)
@@ -293,7 +293,7 @@ def recordMousePositions(amount=None, interval=2, debug=False):
 
     except Exception as e:
         print(e)
-    
+
     finally:
         _debugging('Recorded {} mouse positions.'.format(len(positions_list)))
 


### PR DESCRIPTION
These are the changes I've made over the last month.

- Removed pygame as a mandatory requirement, it will now print "Recorded" to console if pygame is not installed.
- Removed the duplicated code of while/for loop. Instead, if no amount is given then use the systems sys.maxsize value in range and loop over that.
- If the fail safe is triggered, a message will print to the screen as such but the positions list will still be returned.